### PR TITLE
Core: fixed parsing IPv4 address.

### DIFF
--- a/src/core/ngx_inet.c
+++ b/src/core/ngx_inet.c
@@ -16,8 +16,8 @@ static ngx_int_t ngx_inet_add_addr(ngx_pool_t *pool, ngx_url_t *u,
     struct sockaddr *sockaddr, socklen_t socklen, ngx_uint_t total);
 
 
-in_addr_t
-ngx_inet_addr(u_char *text, size_t len)
+ngx_int_t
+ngx_inet_addr(u_char *text, size_t len, in_addr_t *addrp)
 {
     u_char      *p, c;
     in_addr_t    addr;
@@ -34,7 +34,7 @@ ngx_inet_addr(u_char *text, size_t len)
             octet = octet * 10 + (c - '0');
 
             if (octet > 255) {
-                return INADDR_NONE;
+                return NGX_ERROR;
             }
 
             continue;
@@ -47,15 +47,16 @@ ngx_inet_addr(u_char *text, size_t len)
             continue;
         }
 
-        return INADDR_NONE;
+        return NGX_ERROR;
     }
 
     if (n == 3) {
         addr = (addr << 8) + octet;
-        return htonl(addr);
+        *addrp = htonl(addr);
+        return NGX_OK;
     }
 
-    return INADDR_NONE;
+    return NGX_ERROR;
 }
 
 
@@ -66,6 +67,8 @@ ngx_inet6_addr(u_char *p, size_t len, u_char *addr)
 {
     u_char      c, *zero, *digit, *s, *d;
     size_t      len4;
+    in_addr_t   addr4;
+    ngx_int_t   rc;
     ngx_uint_t  n, nibbles, word;
 
     if (len == 0) {
@@ -117,12 +120,12 @@ ngx_inet6_addr(u_char *p, size_t len, u_char *addr)
                 return NGX_ERROR;
             }
 
-            word = ngx_inet_addr(digit, len4 - 1);
-            if (word == INADDR_NONE) {
+            rc = ngx_inet_addr(digit, len4 - 1, &addr4);
+            if (rc != NGX_OK) {
                 return NGX_ERROR;
             }
 
-            word = ntohl(word);
+            word = ntohl(addr4);
             *addr++ = (u_char) ((word >> 24) & 0xff);
             *addr++ = (u_char) ((word >> 16) & 0xff);
             n--;
@@ -388,9 +391,9 @@ ngx_ptocidr(ngx_str_t *text, ngx_cidr_t *cidr)
     mask = ngx_strlchr(addr, last, '/');
     len = (mask ? mask : last) - addr;
 
-    cidr->u.in.addr = ngx_inet_addr(addr, len);
+    rc = ngx_inet_addr(addr, len, &cidr->u.in.addr);
 
-    if (cidr->u.in.addr != INADDR_NONE) {
+    if (rc == NGX_OK) {
         cidr->family = AF_INET;
 
         if (mask == NULL) {
@@ -562,6 +565,7 @@ ngx_int_t
 ngx_parse_addr(ngx_pool_t *pool, ngx_addr_t *addr, u_char *text, size_t len)
 {
     in_addr_t             inaddr;
+    ngx_int_t             rc;
     ngx_uint_t            family;
     struct sockaddr_in   *sin;
 #if (NGX_HAVE_INET6)
@@ -575,9 +579,9 @@ ngx_parse_addr(ngx_pool_t *pool, ngx_addr_t *addr, u_char *text, size_t len)
     ngx_memzero(&inaddr6, sizeof(struct in6_addr));
 #endif
 
-    inaddr = ngx_inet_addr(text, len);
+    rc = ngx_inet_addr(text, len, &inaddr);
 
-    if (inaddr != INADDR_NONE) {
+    if (rc == NGX_OK) {
         family = AF_INET;
         len = sizeof(struct sockaddr_in);
 
@@ -784,7 +788,7 @@ ngx_parse_inet_url(ngx_pool_t *pool, ngx_url_t *u)
 {
     u_char              *host, *port, *last, *uri, *args, *dash;
     size_t               len;
-    ngx_int_t            n;
+    ngx_int_t            n, rc;
     struct sockaddr_in  *sin;
 
     u->socklen = sizeof(struct sockaddr_in);
@@ -957,9 +961,9 @@ no_port:
         return ngx_inet_add_addr(pool, u, &u->sockaddr.sockaddr, u->socklen, 1);
     }
 
-    sin->sin_addr.s_addr = ngx_inet_addr(host, len);
+    rc = ngx_inet_addr(host, len, &sin->sin_addr.s_addr);
 
-    if (sin->sin_addr.s_addr != INADDR_NONE) {
+    if (rc == NGX_OK) {
 
         if (sin->sin_addr.s_addr == INADDR_ANY) {
             u->wildcard = 1;
@@ -1198,6 +1202,7 @@ ngx_int_t
 ngx_inet_resolve_host(ngx_pool_t *pool, ngx_url_t *u)
 {
     u_char              *host;
+    ngx_int_t            rc,
     ngx_uint_t           i, n;
     struct hostent      *h;
     struct sockaddr_in   sin;
@@ -1207,9 +1212,9 @@ ngx_inet_resolve_host(ngx_pool_t *pool, ngx_url_t *u)
     ngx_memzero(&sin, sizeof(struct sockaddr_in));
 
     sin.sin_family = AF_INET;
-    sin.sin_addr.s_addr = ngx_inet_addr(u->host.data, u->host.len);
+    rc = ngx_inet_addr(u->host.data, u->host.len, sin.sin_addr.s_addr);
 
-    if (sin.sin_addr.s_addr == INADDR_NONE) {
+    if (rc == NGX_OK) {
         host = ngx_alloc(u->host.len + 1, pool->log);
         if (host == NULL) {
             return NGX_ERROR;

--- a/src/core/ngx_inet.h
+++ b/src/core/ngx_inet.h
@@ -106,7 +106,7 @@ typedef struct {
 } ngx_url_t;
 
 
-in_addr_t ngx_inet_addr(u_char *text, size_t len);
+ngx_int_t ngx_inet_addr(u_char *text, size_t len, in_addr_t *addrp);
 #if (NGX_HAVE_INET6)
 ngx_int_t ngx_inet6_addr(u_char *p, size_t len, u_char *addr);
 size_t ngx_inet6_ntop(u_char *p, u_char *text, size_t len);

--- a/src/core/ngx_resolver.c
+++ b/src/core/ngx_resolver.c
@@ -366,13 +366,14 @@ ngx_resolver_cleanup_tree(ngx_resolver_t *r, ngx_rbtree_t *tree)
 ngx_resolver_ctx_t *
 ngx_resolve_start(ngx_resolver_t *r, ngx_resolver_ctx_t *temp)
 {
+    ngx_int_t            rc;
     in_addr_t            addr;
     ngx_resolver_ctx_t  *ctx;
 
     if (temp) {
-        addr = ngx_inet_addr(temp->name.data, temp->name.len);
+        rc = ngx_inet_addr(temp->name.data, temp->name.len, &addr);
 
-        if (addr != INADDR_NONE) {
+        if (rc == NGX_OK) {
             temp->resolver = r;
             temp->state = NGX_OK;
             temp->naddrs = 1;

--- a/src/http/modules/ngx_http_geo_module.c
+++ b/src/http/modules/ngx_http_geo_module.c
@@ -676,6 +676,7 @@ ngx_http_geo_range(ngx_conf_t *cf, ngx_http_geo_conf_ctx_t *ctx,
     u_char      *p, *last;
     in_addr_t    start, end;
     ngx_str_t   *net;
+    ngx_int_t    rc;
     ngx_uint_t   del;
 
     if (ngx_strcmp(value[0].data, "default") == 0) {
@@ -729,9 +730,9 @@ ngx_http_geo_range(ngx_conf_t *cf, ngx_http_geo_conf_ctx_t *ctx,
         goto invalid;
     }
 
-    start = ngx_inet_addr(net->data, p - net->data);
+    rc = ngx_inet_addr(net->data, p - net->data, &start);
 
-    if (start == INADDR_NONE) {
+    if (rc != NGX_OK) {
         goto invalid;
     }
 
@@ -739,9 +740,9 @@ ngx_http_geo_range(ngx_conf_t *cf, ngx_http_geo_conf_ctx_t *ctx,
 
     p++;
 
-    end = ngx_inet_addr(p, last - p);
+    rc = ngx_inet_addr(p, last - p, &end);
 
-    if (end == INADDR_NONE) {
+    if (rc != NGX_OK) {
         goto invalid;
     }
 

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -1841,6 +1841,7 @@ ngx_http_upstream_ssl_name(ngx_http_request_t *r, ngx_http_upstream_t *u,
     ngx_connection_t *c)
 {
     u_char     *p, *last;
+    in_addr_t   addr;
     ngx_str_t   name;
 
     if (u->conf->ssl_name) {
@@ -1890,7 +1891,7 @@ ngx_http_upstream_ssl_name(ngx_http_request_t *r, ngx_http_upstream_t *u,
         goto done;
     }
 
-    if (ngx_inet_addr(name.data, name.len) != INADDR_NONE) {
+    if (ngx_inet_addr(name.data, name.len, &addr) != NGX_OK) {
         goto done;
     }
 

--- a/src/stream/ngx_stream_geo_module.c
+++ b/src/stream/ngx_stream_geo_module.c
@@ -626,6 +626,7 @@ ngx_stream_geo_range(ngx_conf_t *cf, ngx_stream_geo_conf_ctx_t *ctx,
     u_char      *p, *last;
     in_addr_t    start, end;
     ngx_str_t   *net;
+    ngx_int_t    rc;
     ngx_uint_t   del;
 
     if (ngx_strcmp(value[0].data, "default") == 0) {
@@ -679,9 +680,9 @@ ngx_stream_geo_range(ngx_conf_t *cf, ngx_stream_geo_conf_ctx_t *ctx,
         goto invalid;
     }
 
-    start = ngx_inet_addr(net->data, p - net->data);
+    rc = ngx_inet_addr(net->data, p - net->data, &start);
 
-    if (start == INADDR_NONE) {
+    if (rc != NGX_OK) {
         goto invalid;
     }
 
@@ -689,9 +690,9 @@ ngx_stream_geo_range(ngx_conf_t *cf, ngx_stream_geo_conf_ctx_t *ctx,
 
     p++;
 
-    end = ngx_inet_addr(p, last - p);
+    rc = ngx_inet_addr(p, last - p, &end);
 
-    if (end == INADDR_NONE) {
+    if (rc != NGX_OK) {
         goto invalid;
     }
 


### PR DESCRIPTION
The ngx_inet_addr function return parsed IPv4 address as the return
value. When failing to parse the input string as an IPv4 address, it
returns INADDR_NONE, which is identical to INADDR_BROADCAST, and
thus we cannot distiguish the two cases.

In this patch, we changed the signature of ngx_inet_addr to return
a status code and the parsed IPv4 address will be returned via an
out parameter as the ngx_inet6_addr function does. Besides this,
the INADDR_BROADCAST check which was done accidently by comparing
the return value of ngx_inet_addr with INADDR_NONE before this patch
should be explicit performed from now on.